### PR TITLE
GH-33: update settings page UI via theme's variables

### DIFF
--- a/frontend/src/components/accordion/index.js
+++ b/frontend/src/components/accordion/index.js
@@ -7,6 +7,7 @@ import Typography from '@mui/material/Typography'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Divider, Grid } from '@mui/material'
 import FormControl from '@mui/material/FormControl'
+import { useTheme } from '@emotion/react'
 import FormHelperLabel from '../formHelperLabel'
 import Input from '../input'
 import RoboTypeIcon from '../roboTypeIcon'
@@ -16,15 +17,14 @@ import Button from '../button'
 import BoxTitle from '../boxTitle'
 
 const AccordionWrapper = styled((props) => (<MuiAccordion {...props}/>))(({ theme }) => ({
-  borderRadius: '16px',
-  boxShadow: '-10px 10px 20px rgba(212, 212, 225, 0.2), 10px -10px 20px rgba(182, 182, 210, 0.2)',
-  background: 'rgba(253, 253, 255, 0.8)',
+  borderRadius: theme.shape.cardBorderRadius,
+  background: theme.palette.background.paper,
   marginBottom: '16px',
   '&:first-of-type': {
-    borderRadius: '16px'
+    borderRadius: theme.shape.cardBorderRadius
   },
   '&:last-of-type': {
-    borderRadius: '16px'
+    borderRadius: theme.shape.cardBorderRadius
   },
   '&:before': {
     display: 'none'
@@ -46,6 +46,7 @@ const Accordion = ({
   robotTypes,
   onRobotUpdate
 }) => {
+  const theme = useTheme()
   const [robotName, setRobotName] = useState(name)
   const [selectedRobotType, setSelectedRobotType] = useState(type)
   const [speedStep, setSpeedStep] = useState(speed_step)
@@ -81,7 +82,7 @@ const Accordion = ({
   return (
     <AccordionWrapper expanded={expanded === index} onChange={onChange(index)}>
       <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMoreIcon color='primary'/>}
         >
           <BoxTitle>{`Robot ${index}`}</BoxTitle>
         </AccordionSummary>
@@ -123,7 +124,7 @@ const Accordion = ({
             </Grid>
             
             <Grid item xs={12}>
-              <Divider sx={{ margin: '12px 0' }}/>
+              <Divider sx={{ margin: '12px 0', borderColor: theme.palette.hr.main }}/>
             </Grid>
             <Grid item xs={12}>
               <Typography sx={{ fontWeight: 'bold', fontSize: '16px' }}>Speed Settings</Typography>

--- a/frontend/src/components/boxTitle/index.js
+++ b/frontend/src/components/boxTitle/index.js
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled"
 import { Typography } from "@mui/material"
 
-const BoxTitle = styled(Typography)`
-  font-size: 18px;
-  line-height: 1.5;
-  font-weight: 600;
-  color: #262748;
-`
+const BoxTitle = styled(Typography)(({ theme }) => ({
+  fontSize: '18px',
+  lineHeight: '1.5',
+  color: theme.palette.text.primary,
+  fontWeight: theme.typography.fontWeightBold
+}))
 
 export default BoxTitle

--- a/frontend/src/components/display/index.js
+++ b/frontend/src/components/display/index.js
@@ -15,7 +15,7 @@ const Display = observer(() => {
 
   return (
     <Paper>
-      <BoxTitle sx={{}}>Display</BoxTitle>
+      <BoxTitle sx={{marginBottom: '24px'}}>Display</BoxTitle>
       <FormControl fullWidth>
         <FormHelperLabel id='theme-select'>Theme</FormHelperLabel>
         <Select

--- a/frontend/src/components/formHelperLabel/index.js
+++ b/frontend/src/components/formHelperLabel/index.js
@@ -1,12 +1,12 @@
 import FormHelperText from '@mui/material/FormHelperText'
 import { styled } from '@mui/material/styles'
 
-const FormHelperLabel = styled(FormHelperText)`
-  color: #262748;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 20px;
-  margin: 0 0 4px;
-`
+const FormHelperLabel = styled(FormHelperText)(({ theme }) => ({
+  fontSize: '12px',
+  lineHeight: '20px',
+  fontWeight: theme.typography.fontWeightRegular,
+  color: theme.palette.primary.main,
+  margin: '0 0 4px'
+}))
 
 export default FormHelperLabel

--- a/frontend/src/components/input/index.js
+++ b/frontend/src/components/input/index.js
@@ -6,9 +6,9 @@ const Input = styled(InputBase)(({ theme }) => ({
   '& .MuiInputBase-input': {
     boxSizing: 'border-box',
     height: '44px',
-    border: '1px solid #B7C0D9',
-    borderRadius: '6px',
-    background: 'transparent',
+    border: `1px solid ${theme.palette.border.formItem}`,
+    borderRadius: theme.shape.formFieldBorderRadius,
+    background: theme.palette.background.formItemBg,
     fontSize: '14px',
     padding: '12px',
     transition: theme.transitions.create([

--- a/frontend/src/components/paper/index.js
+++ b/frontend/src/components/paper/index.js
@@ -1,10 +1,10 @@
 import { default as DefaultPaper } from '@mui/material/Paper'
 import { styled } from '@mui/material/styles'
 
-const Paper = styled(DefaultPaper)`
-  border-radius: 16px;
-  box-shadow: -10px 10px 20px rgba(212, 212, 225, 0.2), 10px -10px 20px rgba(182, 182, 210, 0.2);
-  padding: 24px;
-`
+const Paper = styled(DefaultPaper)(({ theme }) => ({
+  background: theme.palette.background.paper,
+  borderRadius: theme.shape.cardBorderRadius,
+  padding: '24px',
+}))
 
 export default Paper

--- a/frontend/src/components/select/index.js
+++ b/frontend/src/components/select/index.js
@@ -1,14 +1,14 @@
+import { useTheme } from '@emotion/react';
 import ExpandMore from '@mui/icons-material/ExpandMore'
 import {default as DefaultSelect} from '@mui/material/Select'
 import { styled } from '@mui/material/styles'
 
-const Select = styled(
-  (props) => <DefaultSelect {...props} IconComponent={(props) => <ExpandMore {...props}/>} />
-)(({ theme }) => ({
-  borderRadius: '6px',
+const CustomSelect = styled(DefaultSelect)(({ theme }) => ({
+  borderRadius: theme.shape.formFieldBorderRadius,
+  background: theme.palette.background.formItemBg,
   height: '44px',
   '& .MuiSelect-select': {
-    padding: '0 12px',
+    padding: '10px 12px',
     display: 'flex',
     alignItems: 'center'
   },
@@ -27,5 +27,21 @@ const Select = styled(
     },
   },
 }))
+
+const Select = (props) => {
+  const theme = useTheme()
+
+  return <CustomSelect
+    {...props}
+    IconComponent={(iconProps) => <ExpandMore {...iconProps}/>}
+    MenuProps={{
+      PaperProps: {
+        sx: {
+          bgcolor: theme.palette.robotSelect.dropdownBg,
+        },
+      },
+    }}
+  />
+}
 
 export default Select

--- a/frontend/src/components/selectOption/index.js
+++ b/frontend/src/components/selectOption/index.js
@@ -6,7 +6,7 @@ const SelectOption = styled(MenuItem)(({ theme }) => ({
   fontSize: '14px',
   color: theme.palette.primary.main,
   '&.Mui-selected': {
-    color: '#28BDEB',
+    color: theme.palette.info.main,
     background: theme.palette.robotSelect.selectedOptionBg
   },
 }))

--- a/frontend/src/components/switch/index.js
+++ b/frontend/src/components/switch/index.js
@@ -13,7 +13,7 @@ const Switch = styled(Toggle)(({ theme }) => ({
       color: '#fff',
       '& + .MuiSwitch-track': {
         opacity: 1,
-        backgroundColor: '#28BDEB',
+        backgroundColor: theme.palette.info.main,
       },
     },
   },
@@ -28,7 +28,7 @@ const Switch = styled(Toggle)(({ theme }) => ({
   '& .MuiSwitch-track': {
     borderRadius: 16 / 2,
     opacity: 1,
-    backgroundColor: '#B7C0D9',
+    backgroundColor: theme.palette.background.switchOffBg,
     boxSizing: 'border-box',
   },
 }));

--- a/frontend/src/components/widgets/index.js
+++ b/frontend/src/components/widgets/index.js
@@ -5,6 +5,7 @@ import ListItem from '@mui/material/ListItem'
 import { styled } from '@mui/material/styles'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
+import { useTheme } from '@emotion/react'
 import { useStore } from '../../store'
 import Paper from '../paper'
 import BoxTitle from '../boxTitle'
@@ -25,21 +26,22 @@ const ListItemButtonCustom = styled(ListItemButton)(({ theme }) => ({
 }));
 
 const Widgets = observer(() => {
+  const theme = useTheme()
   const {
     settingsStore: { widgets, toggleWidget }
   } = useStore()
 
   return (
     <Paper sx={{marginBottom: '16px'}}>
-      <BoxTitle sx={{}}>Widgets</BoxTitle>
-      <List>
+      <BoxTitle sx={{marginBottom: '24px'}}>Widgets</BoxTitle>
+      <List sx={{padding: 0}}>
         {widgets.map((widget) => (
           <ListItem disablePadding key={widget.id}>
             <ListItemButtonCustom
               selected={widget.selected}
               onClick={() => toggleWidget(widget.id)}
             >
-              <ListItemText primary={widget.label} sx={{color: '#262748'}} />
+              <ListItemText primary={widget.label} sx={{color: theme.palette.text.primary}} />
               <Switch checked={widget.selected} />
             </ListItemButtonCustom>
           </ListItem>

--- a/frontend/src/themes/darkTheme.js
+++ b/frontend/src/themes/darkTheme.js
@@ -26,14 +26,19 @@ const darkTheme = createTheme({
       secondary: '#B7C0D9'
     },
     hr: {
-      main: '#E1E6F4'
+      main: '#80819A'
     },
     button: {
       disabled: '#565873'
     },
     background: {
       main: '#17162D',
-      paper: 'rgba(51, 53, 83, 0.8)'
+      paper: 'rgba(51, 53, 83, 0.8)',
+      formItemBg: '#484A69',
+      switchOffBg: '#4F5171',
+    },
+    border: {
+      formItem: '#777C94',
     },
     robotSelect: {
       iconBg: '#38395C',

--- a/frontend/src/themes/lightTheme.js
+++ b/frontend/src/themes/lightTheme.js
@@ -33,7 +33,12 @@ const lightTheme = createTheme({
     },
     background: {
       main: '#F2F4FC',
-      paper: 'rgba(253, 253, 255, 0.8)'
+      paper: 'rgba(253, 253, 255, 0.8)',
+      formItemBg: '#FFFFFF',
+      switchOffBg: '#B7C0D9',
+    },
+    border: {
+      formItem: '#B7C0D9',
     },
     robotSelect: {
       iconBg: '#E2E7F5',


### PR DESCRIPTION
settings page UI is implemented via theme's config 
now it matches design
<img width="948" alt="Screenshot 2022-11-17 at 14 43 24" src="https://user-images.githubusercontent.com/84070515/202449833-34f709e1-128e-49f5-9505-9497b076a8f9.png">

Closes #33 