### PR TITLE
GH-57: Update tooltip text of full screen icon

### DIFF
--- a/frontend/src/components/videoControls/components/Fullscreen/index.js
+++ b/frontend/src/components/videoControls/components/Fullscreen/index.js
@@ -27,6 +27,8 @@ const Fullscreen = observer(({ connected }) => {
     return isFullscreen ? FullscreenExitIcon : FullscreenIcon
   }
 
+  const fullscreenTitle = isFullscreen ? 'Exit Full Screen' : 'Full Screen'
+
   const theme = useTheme()
 
   const color = connected
@@ -34,7 +36,7 @@ const Fullscreen = observer(({ connected }) => {
     : theme.palette.text.disabledVideoPlayerIcon
 
   return (
-    <Tooltip title='Full screen' placement='top' open={open} onClose={handleClose} onOpen={handleOpen}>
+    <Tooltip title={fullscreenTitle} placement='top' open={open} onClose={handleClose} onOpen={handleOpen}>
       <span>
         <IconButton
           onClick={toggleFullscreen}


### PR DESCRIPTION
Updated a text of the tooltip to 'Exist Full Screen' in the fullscreen mode.
| Normal mode  | Full screen mode |
| ------------- | ------------- |
| <img width="1512" alt="Screenshot 2023-01-31 at 12 03 23" src="https://user-images.githubusercontent.com/8956849/215737016-a1824545-24a0-4a19-b61b-927690acb8f1.png"> | <img width="1216" alt="Screenshot 2023-01-31 at 12 02 40" src="https://user-images.githubusercontent.com/8956849/215736988-a9d0714b-1570-44c5-b82d-7a2377c17bb7.png"> |
